### PR TITLE
core: Add "add" operation for the derived set

### DIFF
--- a/src/Allocations/Set.h
+++ b/src/Allocations/Set.h
@@ -60,6 +60,13 @@ class Set {
       *to++ = *from++;
     }
   }
+  void Add(const Set<Offset> &other) {
+    uint64_t *to = _asU64.get();
+    const uint64_t *from = other._asU64.get();
+    for (AllocationIndex i = 0; i < _numU64; i++) {
+      *to++ |= *from++;
+    }
+  }
   void Subtract(const Set<Offset> &other) {
     uint64_t *to = _asU64.get();
     const uint64_t *from = other._asU64.get();


### PR DESCRIPTION
This commit adds "add" operation for the derived set using the set of allocations and complete the help information.

To add some allocation calculated set S' to the derived set, add the following to any command that calculates S':
  /setOperation add

The derived set is then referred to as "derived".
Closes #17